### PR TITLE
Switch from rcov to simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "http://rubygems.org"
 group :development do
   gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.6.4"
-  gem "rcov", ">= 0"
   gem "rdoc", ">= 0"
   gem "shoulda"
   
@@ -11,5 +10,7 @@ group :development do
   gem "vcr"
   gem "webmock"
 end
+
+gem 'simplecov', :require => false, :group => :test
 
 gem "nokogiri", ">= 0"

--- a/README.rdoc
+++ b/README.rdoc
@@ -69,6 +69,7 @@ MusicBrainz::Track
 * Start a feature/bugfix branch
 * Commit and push until you are happy with your contribution
 * Make sure to add tests for it. This is important so I don't break it in a future version unintentionally.
+* to get a coverage report for your Test Unit and RSpec tests use the rake tasks: test_coverage, rspec_coverage
 * Please try not to mess with the Rakefile, version, or history. If you want to have your own version, or is otherwise necessary, that is fine, but please isolate to its own commit so I can cherry-pick around it.
 
 === Copyright

--- a/Rakefile
+++ b/Rakefile
@@ -32,12 +32,21 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-require 'rcov/rcovtask'
-Rcov::RcovTask.new do |test|
-  test.libs << 'test'
-  test.pattern = 'test/**/test_*.rb'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |test|
   test.verbose = true
-  test.rcov_opts << '--exclude "gems/*"'
+end
+
+desc "Run Test Unit with code coverage"
+task :test_coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task["test"].execute
+end
+
+desc "Run RSpec with code coverage"
+task :rspec_coverage do
+  ENV['COVERAGE'] = 'true'
+  Rake::Task["spec"].execute
 end
 
 task :default => :test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,13 @@
+require 'simplecov'
+
+if ENV["COVERAGE"]
+  SimpleCov.start do
+    add_filter '/gems/'
+    add_filter '/test/'
+    add_filter '/spec/'
+  end
+end
+
 require 'rubygems'
 require 'bundler'
 begin

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,13 @@
+require 'simplecov'
+
+if ENV["COVERAGE"]
+  SimpleCov.start do
+    add_filter '/gems/'
+    add_filter '/test/'
+    add_filter '/spec/'
+  end
+end
+
 require 'rubygems'
 require 'bundler'
 begin


### PR DESCRIPTION
To get the musicbrainz gem running with Ruby 1.9 I replaced rcov by simplecov which is even highly recommended on the github page of rcov.

The coverage reports for rspec and unit tests will be generated with the rake tasks: rspec_coverage, test_coverage

... otherwise bundle install would raise this exception:

<pre>
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /Users/mgawlista/.rvm/rubies/ruby-1.9.3-p125/bin/ruby extconf.rb 
**** Ruby 1.9 is not supported. Please switch to simplecov ****


Gem files will remain installed in /Users/mgawlista/.rvm/gems/ruby-1.9.3-p125@musicbrainz/gems/rcov-1.0.0 for inspection.
Results logged to /Users/mgawlista/.rvm/gems/ruby-1.9.3-p125@musicbrainz/gems/rcov-1.0.0/ext/rcovrt/gem_make.out
An error occured while installing rcov (1.0.0), and Bundler cannot continue.
Make sure that `gem install rcov -v '1.0.0'` succeeds before bundling.
</pre>
