### PR TITLE
Make use of MusicBrainz' scoring scheme

### DIFF
--- a/lib/musicbrainz/artist.rb
+++ b/lib/musicbrainz/artist.rb
@@ -46,19 +46,6 @@ module MusicBrainz
           :query => CGI.escape(name).gsub(/\!/, '\!') + '~',
           :limit => 50
         })
-        artists.each { |artist|
-          if artist[:name].downcase == name.downcase
-            artist[:weight] += 80
-          elsif artist[:name].downcase.gsub(/\s/, "") == name.downcase.gsub(/\s/, "")
-            artist[:weight] += 25
-          elsif artist[:aliases].include? name
-            artist[:weight] += 20
-          elsif artist[:aliases].map { |item| item.downcase }.include?(name.downcase)
-            artist[:weight] += 10
-          elsif artist[:aliases].map { |item| item.downcase.gsub(/\s/, "") }.include?(name.downcase.gsub(/\s/, ""))
-            artist[:weight] += 5
-          end
-        }
         artists.sort{ |a, b| b[:weight] <=> a[:weight] }.take(10)
       end
 

--- a/lib/parsers/artist.rb
+++ b/lib/parsers/artist.rb
@@ -26,7 +26,7 @@ module MusicBrainz
             artists << {
               :name => a.first_element_child.text.gsub(/[`’]/, "'"),
               :sort_name => safe_get_value(a, "sort-name").gsub(/[`’]/, "'"),
-              :weight => 0,
+              :score => (safe_get_attr(a, nil, "score") .to_i rescue 0),
               :desc => safe_get_value(a, "disambiguation"),
               :type => safe_get_attr(a, nil, "type"),
               :mbid => safe_get_attr(a, nil, "id"),

--- a/spec/requests/artist_spec.rb
+++ b/spec/requests/artist_spec.rb
@@ -20,6 +20,19 @@ describe MusicBrainz::Artist do
     matches.first[:name].should == "Kasabian"
   end
 
+  it "should return search results in the right order and pass back the correct score" do
+    matches = MusicBrainz::Artist.search('Chris Martin')
+    
+    matches.first[:score].should == 100
+    matches.first[:mbid].should == "98d1ec5a-dd97-4c0b-9c83-7928aac89bca"
+    matches[1][:score].should == 100
+    matches[1][:mbid].should == "af2ab893-3212-4226-9e73-73a1660b6952"
+    matches[2][:score].should == 95
+    matches[2][:mbid].should == "444d1b63-534b-4ea6-89f0-0af6ab2e20c3"
+    matches[3][:score].should == 95
+    matches[3][:mbid].should == "90fff570-a4ef-4cd4-ba21-e00c7261b05a"
+  end
+  
   it "finds name first than alias" do
     matches = MusicBrainz::Artist.search('Chris Martin')
     matches.length.should be > 0


### PR DESCRIPTION
Instead of relying on the score returned by MusicBrainz indicating the match of an artist with the search query, a custom weighting implementation is used. This implementation delivers unreliable results and does not match MusicBrainz scoring scheme. This change removes the custom implementation and makes use of MB's matching score.

Oh, and I've also fixed an already failing spec.
