### PR TITLE
BaseModel.search might return nil

### DIFF
--- a/lib/musicbrainz/models/artist.rb
+++ b/lib/musicbrainz/models/artist.rb
@@ -36,7 +36,9 @@ module MusicBrainz
 
       def find_by_name(name)
         matches = search(name)
-        matches.empty? ? nil : find(matches.first[:id])
+        if matches and not matches.empty?
+          find(matches.first[:id])
+        end
       end
     end
   end


### PR DESCRIPTION
I've seen this error in airbrake a couple of times.

![skarmavbild 2013-11-06 kl 22 38 50](https://f.cloud.github.com/assets/220827/1486950/ed1150a4-472b-11e3-8cd4-d9f3a8a27e92.png)

I'm not sure why, but 1 out of 10^4 times (or something similar) `BaseModel.search` returns nil.

This PR will fix this error. 

All specs passes.
