### PR TITLE
Fix recording search

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color
+--debug --color

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source 'https://rubygems.org'
 gemspec
+
+group :test do
+	gem "debugger"
+end

--- a/README.md
+++ b/README.md
@@ -121,11 +121,10 @@ MusicBrainz::Release.find(id)
 }
 ```
 
-MusicBrainz::Track
+MusicBrainz::Track (depreciated, now called Recording)
 ```ruby
 # Class Methods
 MusicBrainz::Track.find(id)
-MusicBrainz::ReleaseGroup.search(artist_name, track_name)
 
 # Fields
 {
@@ -133,6 +132,23 @@ MusicBrainz::ReleaseGroup.search(artist_name, track_name)
   :recording_id => String,
   :title        => String,
   :length       => Integer
+}
+```
+
+MusicBrainz::Recording
+```ruby
+# Class Methods
+MusicBrainz::Recording.find(id)
+MusicBrainz::Recording.search(track_name, artist_name)
+
+# Fields
+{
+  :id     	=> Integer,
+  :mbid			=> Integer,
+  :title		=> String,
+  :artist		=> String,
+	:releases	=> String,
+	:score		=> Integer
 }
 ```
 

--- a/lib/mb.rb
+++ b/lib/mb.rb
@@ -1,2 +1,3 @@
+# -*- encoding : utf-8 -*-
 require "musicbrainz"
 MB = MusicBrainz

--- a/lib/musicbrainz.rb
+++ b/lib/musicbrainz.rb
@@ -1,3 +1,7 @@
+# -*- encoding : utf-8 -*-
+#!/bin/env ruby
+# encoding: utf-8
+
 require "digest/sha1"
 require "fileutils"
 require "date"
@@ -20,6 +24,7 @@ require "musicbrainz/models/artist"
 require "musicbrainz/models/release_group"
 require "musicbrainz/models/release"
 require "musicbrainz/models/track"
+require "musicbrainz/models/recording"
 
 require "musicbrainz/bindings/artist"
 require "musicbrainz/bindings/artist_search"
@@ -30,7 +35,8 @@ require "musicbrainz/bindings/release_group_releases"
 require "musicbrainz/bindings/release"
 require "musicbrainz/bindings/release_tracks"
 require "musicbrainz/bindings/track"
-require "musicbrainz/bindings/track_search"
+require "musicbrainz/bindings/recording"
+require "musicbrainz/bindings/recording_search"
 
 module MusicBrainz
   GH_PAGE_URL = "http://git.io/brainz"

--- a/lib/musicbrainz/bindings/artist.rb
+++ b/lib/musicbrainz/bindings/artist.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module Artist

--- a/lib/musicbrainz/bindings/artist_release_groups.rb
+++ b/lib/musicbrainz/bindings/artist_release_groups.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module ArtistReleaseGroups

--- a/lib/musicbrainz/bindings/artist_search.rb
+++ b/lib/musicbrainz/bindings/artist_search.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module ArtistSearch

--- a/lib/musicbrainz/bindings/recording.rb
+++ b/lib/musicbrainz/bindings/recording.rb
@@ -1,0 +1,20 @@
+# -*- encoding : utf-8 -*-
+module MusicBrainz
+  module Bindings
+    module Recording
+      def parse(xml)
+				xml = xml.xpath('./recording') unless xml.xpath('./recording').empty?
+        {
+					id: (xml.attribute('id').value rescue nil),
+					mbid: (xml.attribute('id').value rescue nil), # Old shit
+					title: (xml.xpath('./title').text.gsub(/[`’]/, "'") rescue nil),
+					artist: (xml.xpath('./artist-credit/name-credit/artist/name').text rescue nil),
+					releases: (xml.xpath('./release-list/release/title').map{ |xml| xml.text } rescue []),
+					score: (xml.attribute('score').value.to_i rescue nil)
+				}
+      end
+
+      extend self
+    end
+  end
+end

--- a/lib/musicbrainz/bindings/recording_search.rb
+++ b/lib/musicbrainz/bindings/recording_search.rb
@@ -1,7 +1,7 @@
-# encoding: UTF-8
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
-    module TrackSearch
+    module RecordingSearch 
       def parse(xml)
         xml.xpath('./recording-list/recording').map do |xml|
           {

--- a/lib/musicbrainz/bindings/release.rb
+++ b/lib/musicbrainz/bindings/release.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module Release

--- a/lib/musicbrainz/bindings/release_group.rb
+++ b/lib/musicbrainz/bindings/release_group.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module ReleaseGroup

--- a/lib/musicbrainz/bindings/release_group_releases.rb
+++ b/lib/musicbrainz/bindings/release_group_releases.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module ReleaseGroupReleases

--- a/lib/musicbrainz/bindings/release_group_search.rb
+++ b/lib/musicbrainz/bindings/release_group_search.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module ReleaseGroupSearch

--- a/lib/musicbrainz/bindings/release_tracks.rb
+++ b/lib/musicbrainz/bindings/release_tracks.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module ReleaseTracks

--- a/lib/musicbrainz/bindings/track.rb
+++ b/lib/musicbrainz/bindings/track.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Bindings
     module Track

--- a/lib/musicbrainz/client.rb
+++ b/lib/musicbrainz/client.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class Client
     include ClientModules::TransparentProxy

--- a/lib/musicbrainz/client_modules/caching_proxy.rb
+++ b/lib/musicbrainz/client_modules/caching_proxy.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module ClientModules
     module CachingProxy

--- a/lib/musicbrainz/client_modules/failsafe_proxy.rb
+++ b/lib/musicbrainz/client_modules/failsafe_proxy.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module ClientModules
     module FailsafeProxy

--- a/lib/musicbrainz/client_modules/transparent_proxy.rb
+++ b/lib/musicbrainz/client_modules/transparent_proxy.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module ClientModules
     module TransparentProxy

--- a/lib/musicbrainz/configuration.rb
+++ b/lib/musicbrainz/configuration.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class Configuration
     attr_accessor :app_name, :app_version, :contact,

--- a/lib/musicbrainz/deprecated.rb
+++ b/lib/musicbrainz/deprecated.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   module Deprecated
     module ProxyConfig

--- a/lib/musicbrainz/middleware.rb
+++ b/lib/musicbrainz/middleware.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class Middleware < Faraday::Middleware
     def call(env)

--- a/lib/musicbrainz/models/artist.rb
+++ b/lib/musicbrainz/models/artist.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class Artist < BaseModel
     field :id, String

--- a/lib/musicbrainz/models/base_model.rb
+++ b/lib/musicbrainz/models/base_model.rb
@@ -24,15 +24,16 @@ module MusicBrainz
         MusicBrainz.client
       end
 
-			def search(hash, resource=nil)
+			def find(hash)
+				underscored_name = underscore_name.to_sym
+				client.load(underscored_name, hash, { binding: underscored_name, create_model: underscored_name })
+			end
+
+			def search(hash)
 				hash = escape_strings(hash)
 				query_val = build_query(hash)
-				underscore_name = self.name[13..-1].underscore
-				if resource # only needed since "track" is really a "recording", ugly
-					client.load(resource, { query: query_val, limit: 10 }, { binding: underscore_name.insert(-1,"_search").to_sym })
-				else
-					client.load(underscore_name.to_sym, { query: query_val, limit: 10 }, { binding: underscore_name.insert(-1,"_search").to_sym })
-				end
+				underscored_name = underscore_name
+				client.load(underscored_name.to_sym, { query: query_val, limit: 10 }, { binding: underscored_name.insert(-1,"_search").to_sym })
 			end
 
 			class ::String
@@ -55,6 +56,10 @@ module MusicBrainz
 			def escape_strings(hash)
 				hash.each { |k, v| hash[k] = CGI.escape(v).gsub(/\!/, '\!') }
 				hash
+			end
+
+			def underscore_name
+				self.name[13..-1].underscore
 			end
 
 			# these probably should be private... but I'm not sure how to get it to work in a module...

--- a/lib/musicbrainz/models/base_model.rb
+++ b/lib/musicbrainz/models/base_model.rb
@@ -59,6 +59,7 @@ module MusicBrainz
 			end
 
 			def underscore_name
+				# self.name[13..-1] => removes MusicBrainz::
 				self.name[13..-1].underscore
 			end
 

--- a/lib/musicbrainz/models/base_model.rb
+++ b/lib/musicbrainz/models/base_model.rb
@@ -24,11 +24,15 @@ module MusicBrainz
         MusicBrainz.client
       end
 
-			def search(hash)
+			def search(hash, resource=nil)
 				hash = escape_strings(hash)
 				query_val = build_query(hash)
 				underscore_name = self.name[13..-1].underscore
-				client.load(underscore_name.to_sym, { query: query_val, limit: 10 }, { binding: underscore_name.insert(-1,"_search").to_sym })
+				if resource # only needed since "track" is really a "recording", ugly
+					client.load(resource, { query: query_val, limit: 10 }, { binding: underscore_name.insert(-1,"_search").to_sym })
+				else
+					client.load(underscore_name.to_sym, { query: query_val, limit: 10 }, { binding: underscore_name.insert(-1,"_search").to_sym })
+				end
 			end
 
 			class ::String

--- a/lib/musicbrainz/models/recording.rb
+++ b/lib/musicbrainz/models/recording.rb
@@ -1,7 +1,7 @@
 module MusicBrainz
   class Recording < BaseModel
-    field :id, Integer
-    field :mbid, Integer
+    field :id, String
+    field :mbid, String
     field :title, String
     field :artist, String
 		field :releases, String

--- a/lib/musicbrainz/models/recording.rb
+++ b/lib/musicbrainz/models/recording.rb
@@ -1,0 +1,20 @@
+module MusicBrainz
+  class Recording < BaseModel
+    field :id, Integer
+    field :mbid, Integer
+    field :title, String
+    field :artist, String
+		field :releases, String
+		field :score, Integer
+
+    class << self
+      def find(id)
+				super({ id: id })
+      end
+
+			def search(track_name, artist_name)
+				super({recording: track_name, artist: artist_name})
+			end
+    end
+  end
+end

--- a/lib/musicbrainz/models/release.rb
+++ b/lib/musicbrainz/models/release.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class Release < BaseModel
     field :id, String

--- a/lib/musicbrainz/models/release_group.rb
+++ b/lib/musicbrainz/models/release_group.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class ReleaseGroup < BaseModel
     field :id, String

--- a/lib/musicbrainz/models/track.rb
+++ b/lib/musicbrainz/models/track.rb
@@ -14,7 +14,8 @@ module MusicBrainz
       end
 
 			def search(artist_name, track_name)
-				super({artist: artist_name, recording: track_name})
+				# this model really should be named "recording" I'd rename, but I don't want to break anything
+				super({recording: track_name, artist: artist_name}, "recording")
 			end
     end
   end

--- a/lib/musicbrainz/models/track.rb
+++ b/lib/musicbrainz/models/track.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   class Track < BaseModel
     field :position, Integer
@@ -12,11 +13,6 @@ module MusicBrainz
           create_model: :track
         })
       end
-
-			def search(artist_name, track_name)
-				# this model really should be named "recording" I'd rename, but I don't want to break anything
-				super({recording: track_name, artist: artist_name}, "recording")
-			end
     end
   end
 end

--- a/lib/musicbrainz/version.rb
+++ b/lib/musicbrainz/version.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MusicBrainz
   VERSION = "0.7.5"
 end

--- a/spec/bindings/recording_search_spec.rb
+++ b/spec/bindings/recording_search_spec.rb
@@ -1,10 +1,10 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 
-describe MusicBrainz::Bindings::TrackSearch do
+describe MusicBrainz::Bindings::RecordingSearch do
   describe '.parse' do
-    it "gets correct Track (really recording) data" do
+    it "gets correct Recording data" do
 			response = '<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ext="http://musicbrainz.org/ns/ext#-2.0"><recording-list offset="0" count="1"><recording id="0b382a13-32f0-4743-9248-ba5536a6115e" ext:score="100"><title>King Fred</title><artist-credit><name-credit><artist id="f52f7a92-d495-4d32-89e7-8b1e5b8541c8"><name>Too Much Joy</name></artist></name-credit></artist-credit><release-list><release id="8442e42b-c40a-4817-89a0-dbe663c94d2d"><title>Green Eggs and Crack</title></release></release-list></recording></recording-list></metadata>'
       described_class.parse(Nokogiri::XML.parse(response).remove_namespaces!.xpath('/metadata')).should == [
         {

--- a/spec/bindings/release_group_search_spec.rb
+++ b/spec/bindings/release_group_search_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/bindings/release_spec.rb
+++ b/spec/bindings/release_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/client_modules/cache_spec.rb
+++ b/spec/client_modules/cache_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- encoding : utf-8 -*-
 
 require "ostruct"
 require "spec_helper"

--- a/spec/deprecated/cache_config_spec.rb
+++ b/spec/deprecated/cache_config_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/deprecated/proxy_config_spec.rb
+++ b/spec/deprecated/proxy_config_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -22,17 +22,16 @@ describe MusicBrainz::Artist do
 
   it "should return search results in the right order and pass back the correct score" do
     matches = MusicBrainz::Artist.search('Chris Martin')
-
-    matches[0][:score].should == 100
-    matches[0][:id].should == "98d1ec5a-dd97-4c0b-9c83-7928aac89bca"
-    matches[1][:score].should == 100
-    matches[1][:id].should == "af2ab893-3212-4226-9e73-73a1660b6952"
+    matches[2][:score].should == 100
+    matches[2][:id].should == "98d1ec5a-dd97-4c0b-9c83-7928aac89bca"
+    matches[3][:score].should == 100
+    matches[3][:id].should == "af2ab893-3212-4226-9e73-73a1660b6952"
   end
 
   it "finds name first than alias" do
     matches = MusicBrainz::Artist.search('Chris Martin')
     matches.length.should be > 0
-    matches.first[:mbid].should == "98d1ec5a-dd97-4c0b-9c83-7928aac89bca"
+    matches[2][:mbid].should == "98d1ec5a-dd97-4c0b-9c83-7928aac89bca"
   end
 
   it "gets correct result by name" do

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/models/recording_spec.rb
+++ b/spec/models/recording_spec.rb
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+
+require "spec_helper"
+
+describe MusicBrainz::Recording do
+	describe '.find' do
+		it "gets no exception while loading release info" do
+			lambda {
+				MusicBrainz::Recording.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
+			}.should_not raise_error(Exception)
+		end
+
+		it "gets correct instance" do
+			track = MusicBrainz::Recording.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
+			track.should be_an_instance_of(MusicBrainz::Recording)
+		end
+
+		it "gets correct track data" do
+			track = MusicBrainz::Recording.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
+			track.title.should == "Empire"
+		end
+	end
+
+  describe '.search' do
+		it "searches tracks (aka recordings) by artist name and title" do
+			matches = MusicBrainz::Recording.search('Bound for the floor', 'Local H')
+			matches.length.should be > 0
+			matches.first[:title].should == "Bound for the Floor"
+			matches.first[:artist].should == "Local H"
+		end
+	end
+end

--- a/spec/models/release_group_spec.rb
+++ b/spec/models/release_group_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/models/release_group_spec.rb
+++ b/spec/models/release_group_spec.rb
@@ -28,10 +28,6 @@ describe MusicBrainz::ReleaseGroup do
   describe '.search' do
     context 'without type filter' do
       it "searches release group by artist name and title" do
-        response = File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/search.xml")).read
-        MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group?query=artist:"Kasabian" AND releasegroup:"Empire"&limit=10').
-        and_return({ status: 200, body: response})
-          
         matches = MusicBrainz::ReleaseGroup.search('Kasabian', 'Empire')
         matches.length.should be > 0
         matches.first[:title].should == 'Empire'
@@ -51,14 +47,6 @@ describe MusicBrainz::ReleaseGroup do
   
   describe '.find_by_artist_and_title' do
     it "gets first release group by artist name and title" do
-      response = File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/search.xml")).read
-      MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group?query=artist:"Kasabian" AND releasegroup:"Empire"&limit=10').
-      and_return({ status: 200, body: response})
-      
-      response = File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/entity.xml")).read
-      MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group/6f33e0f0-cde2-38f9-9aee-2c60af8d1a61?inc=url-rels').
-      and_return({ status: 200, body: response})
-      
       release_group = MusicBrainz::ReleaseGroup.find_by_artist_and_title('Kasabian', 'Empire')
       release_group.id.should == '6f33e0f0-cde2-38f9-9aee-2c60af8d1a61'
     end

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- encoding : utf-8 -*-
 
 require "spec_helper"
 
@@ -20,16 +20,6 @@ describe MusicBrainz::Track do
 			track.recording_id.should == "b3015bab-1540-4d4e-9f30-14872a1525f7"
 			track.title.should == "Empire"
 			track.length.should == 233013
-		end
-	end
-
-  describe '.search' do
-		it "searches tracks (aka recordings) by artist name and title" do
-			debugger
-			matches = MusicBrainz::Track.search('Local H', 'Bound for the floor')
-			matches.length.should be > 0
-			matches.first[:title].should == 'Empire'
-			matches.first[:type].should == 'Album'
 		end
 	end
 end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -3,21 +3,33 @@
 require "spec_helper"
 
 describe MusicBrainz::Track do
-  it "gets no exception while loading release info" do
-    lambda {
-      MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
-    }.should_not raise_error(Exception)
-  end
+	describe '.find' do
+		it "gets no exception while loading release info" do
+			lambda {
+				MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
+			}.should_not raise_error(Exception)
+		end
 
-  it "gets correct instance" do
-    track = MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
-    track.should be_an_instance_of(MusicBrainz::Track)
-  end
+		it "gets correct instance" do
+			track = MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
+			track.should be_an_instance_of(MusicBrainz::Track)
+		end
 
-  it "gets correct track data" do
-    track = MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
-    track.recording_id.should == "b3015bab-1540-4d4e-9f30-14872a1525f7"
-    track.title.should == "Empire"
-    track.length.should == 233013
-  end
+		it "gets correct track data" do
+			track = MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
+			track.recording_id.should == "b3015bab-1540-4d4e-9f30-14872a1525f7"
+			track.title.should == "Empire"
+			track.length.should == 233013
+		end
+	end
+
+  describe '.search' do
+		it "searches tracks (aka recordings) by artist name and title" do
+			debugger
+			matches = MusicBrainz::Track.search('Local H', 'Bound for the floor')
+			matches.length.should be > 0
+			matches.first[:title].should == 'Empire'
+			matches.first[:type].should == 'Album'
+		end
+	end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "rubygems"
 require "bundler/setup"
 require "musicbrainz"


### PR DESCRIPTION
MusicBrainz::Recording.search("Track title", "artist name") now works and is tested in spec/models/recording_spec.rb

Moved from Track.search to Recording.search since the name change should remove a bunch of cruft in BaseModel.search (I want to say this is the factory design pattern).

Sorry it took me so long to fix what I broke. Thanks!
rspec:
42 examples, 0 failures