### PR TITLE
Update to use modern RSpec syntax and conventions

### DIFF
--- a/musicbrainz.gemspec
+++ b/musicbrainz.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('awesome_print')
   gem.add_development_dependency('rake', '~> 10.4.0')
+  gem.add_development_dependency('pry')
 end

--- a/spec/bindings/relations_spec.rb
+++ b/spec/bindings/relations_spec.rb
@@ -15,11 +15,11 @@ describe MusicBrainz::Bindings::Relations do
                 </relation>
               </relation-list></artist>}
             )
-            
-            described_class.parse(xml.xpath('./artist'))[:urls][:social_network].should == 'https://plus.google.com/+Madonna'
+
+            expect(described_class.parse(xml.xpath('./artist'))[:urls][:social_network]).to eq 'https://plus.google.com/+Madonna'
           end
         end
-        
+
         context 'multiple urls for relation types' do
           it 'returns an array' do
             xml = Nokogiri::XML.parse(
@@ -33,7 +33,7 @@ describe MusicBrainz::Bindings::Relations do
               </relation-list></artist>}
             )
 
-            described_class.parse(xml.xpath('./artist'))[:urls][:social_network].should == [
+            expect(described_class.parse(xml.xpath('./artist'))[:urls][:social_network]).to eq [
               'https://plus.google.com/+Madonna', 'https://www.facebook.com/madonna'
             ]
           end

--- a/spec/bindings/release_group_search_spec.rb
+++ b/spec/bindings/release_group_search_spec.rb
@@ -4,14 +4,20 @@ require "spec_helper"
 
 describe MusicBrainz::Bindings::ReleaseGroupSearch do
   describe '.parse' do
+    let(:response) {
+      '<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ext="http://musicbrainz.org/ns/ext#-2.0"><release-group-list><release-group id="246bc928-2dc8-35ba-80ee-7a0079de1632" type="Single" ext:score="100"><title>Empire</title></release-group></release-group-list></metadata>'
+    }
+    let(:metadata) {
+      described_class.parse(Nokogiri::XML.parse(response).remove_namespaces!.xpath('/metadata'))
+    }
+
     it "gets correct release group data" do
-      response = '<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ext="http://musicbrainz.org/ns/ext#-2.0"><release-group-list><release-group id="246bc928-2dc8-35ba-80ee-7a0079de1632" type="Single" ext:score="100"><title>Empire</title></release-group></release-group-list></metadata>'
-      described_class.parse(Nokogiri::XML.parse(response).remove_namespaces!.xpath('/metadata')).should == [
+      expect(metadata).to eq([
         {
-          id: '246bc928-2dc8-35ba-80ee-7a0079de1632', mbid: '246bc928-2dc8-35ba-80ee-7a0079de1632', 
+          id: '246bc928-2dc8-35ba-80ee-7a0079de1632', mbid: '246bc928-2dc8-35ba-80ee-7a0079de1632',
           title: 'Empire', type: 'Single', score: 100
         }
-      ]
+      ])
     end
   end
 end

--- a/spec/bindings/release_spec.rb
+++ b/spec/bindings/release_spec.rb
@@ -10,31 +10,31 @@ describe MusicBrainz::Bindings::Release do
           it 'returns CD' do
             response = '<release><medium-list count="1"><medium><format>CD</format></medium></medium-list></release>'
             xml = Nokogiri::XML.parse(response)
-            described_class.parse(xml)[:format].should == 'CD'
+            expect(described_class.parse(xml)[:format]).to eq 'CD'
           end
         end
-        
+
         context 'multiple cds' do
           it 'returns 2xCD' do
             response = '<release><medium-list count="2"><medium><format>CD</format><track-list count="11" /></medium><medium><title>bonus disc</title><format>CD</format></medium></medium-list></release>'
             xml = Nokogiri::XML.parse(response)
-            described_class.parse(xml)[:format].should == '2xCD'
+            expect(described_class.parse(xml)[:format]).to eq '2xCD'
           end
         end
-        
+
         context 'different formats' do
           it 'returns DVD + CD' do
             response = '<release><medium-list count="2"><medium><format>DVD</format></medium><medium><format>CD</format></medium></medium-list></release>'
             xml = Nokogiri::XML.parse(response)
-            described_class.parse(xml)[:format].should == 'DVD + CD'
+            expect(described_class.parse(xml)[:format]).to eq 'DVD + CD'
           end
         end
-        
+
         context 'different formats plus multiple mediums with same format' do
           it 'returns 2xCD + DVD' do
             response = '<release><medium-list count="2"><medium><format>CD</format></medium><medium><format>CD</format></medium><medium><format>DVD</format></medium></medium-list></release>'
             xml = Nokogiri::XML.parse(response)
-            described_class.parse(xml)[:format].should == '2xCD + DVD'
+            expect(described_class.parse(xml)[:format]).to eq '2xCD + DVD'
           end
         end
       end

--- a/spec/bindings/track_search_spec.rb
+++ b/spec/bindings/track_search_spec.rb
@@ -6,9 +6,9 @@ describe MusicBrainz::Bindings::TrackSearch do
   describe '.parse' do
     it "gets correct Track (really recording) data" do
 			response = '<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ext="http://musicbrainz.org/ns/ext#-2.0"><recording-list offset="0" count="1"><recording id="0b382a13-32f0-4743-9248-ba5536a6115e" ext:score="100"><title>King Fred</title><artist-credit><name-credit><artist id="f52f7a92-d495-4d32-89e7-8b1e5b8541c8"><name>Too Much Joy</name></artist></name-credit></artist-credit><release-list><release id="8442e42b-c40a-4817-89a0-dbe663c94d2d"><title>Green Eggs and Crack</title></release></release-list></recording></recording-list></metadata>'
-      described_class.parse(Nokogiri::XML.parse(response).remove_namespaces!.xpath('/metadata')).should == [
+      expect(described_class.parse(Nokogiri::XML.parse(response).remove_namespaces!.xpath('/metadata'))).to eq [
         {
-          id: '0b382a13-32f0-4743-9248-ba5536a6115e', mbid: '0b382a13-32f0-4743-9248-ba5536a6115e', 
+          id: '0b382a13-32f0-4743-9248-ba5536a6115e', mbid: '0b382a13-32f0-4743-9248-ba5536a6115e',
           title: 'King Fred', artist: 'Too Much Joy', releases: ['Green Eggs and Crack'], score: 100
         }
       ]

--- a/spec/deprecated/cache_config_spec.rb
+++ b/spec/deprecated/cache_config_spec.rb
@@ -18,15 +18,15 @@ describe MusicBrainz::Deprecated::CacheConfig do
   it "allows deprecated use of cache_path" do
     MusicBrainz.config.cache_path = "test1"
 
-    MusicBrainz::Tools::Cache.cache_path.should == "test1"
-    MusicBrainz.cache_path.should == "test1"
+    expect(MusicBrainz::Tools::Cache.cache_path).to eq "test1"
+    expect(MusicBrainz.cache_path).to eq "test1"
   end
 
   it "allows deprecated use of cache_path=" do
     MusicBrainz::Tools::Cache.cache_path = "test2"
-    MusicBrainz.config.cache_path.should == "test2"
+    expect(MusicBrainz.config.cache_path).to eq "test2"
 
     MusicBrainz.cache_path = "test3"
-    MusicBrainz.config.cache_path.should == "test3"
+    expect(MusicBrainz.config.cache_path).to eq "test3"
   end
 end

--- a/spec/deprecated/proxy_config_spec.rb
+++ b/spec/deprecated/proxy_config_spec.rb
@@ -18,15 +18,15 @@ describe MusicBrainz::Deprecated::ProxyConfig do
   it "allows deprecated use of query_interval" do
     MusicBrainz.config.query_interval = 2
 
-    MusicBrainz::Tools::Proxy.query_interval.should == 2
-    MusicBrainz.query_interval.should == 2
+    expect(MusicBrainz::Tools::Proxy.query_interval).to eq 2
+    expect(MusicBrainz.query_interval).to eq 2
   end
 
   it "allows deprecated use of query_interval=" do
     MusicBrainz::Tools::Proxy.query_interval = 3
-    MusicBrainz.config.query_interval.should == 3
+    expect(MusicBrainz.config.query_interval).to eq 3
 
     MusicBrainz.query_interval = 4
-    MusicBrainz.config.query_interval.should == 4
+    expect(MusicBrainz.config.query_interval).to eq 4
   end
 end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -4,56 +4,57 @@ require "spec_helper"
 
 describe MusicBrainz::Artist do
   it "gets no exception while loading artist info" do
-    lambda {
+    expect {
       MusicBrainz::Artist.find('69b39eab-6577-46a4-a9f5-817839092033')
-    }.should_not raise_error(Exception)
+    }.to_not raise_error(Exception)
   end
 
   it "gets correct instance" do
     artist = MusicBrainz::Artist.find_by_name('Kasabian')
-    artist.should be_an_instance_of(MusicBrainz::Artist)
+    expect(artist).to be_instance_of(MusicBrainz::Artist)
   end
 
   it "searches artist by name" do
     matches = MusicBrainz::Artist.search('Kasabian')
-    matches.length.should be > 0
-    matches.first[:name].should == "Kasabian"
+    expect(matches).to_not be_empty
+    expect(matches.first[:name]).to eq("Kasabian")
   end
 
   it "should return search results in the right order and pass back the correct score" do
     response = File.open(File.join(File.dirname(__FILE__), "../fixtures/artist/search.xml")).read
-    MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/artist?query=artist:"Chris+Martin"&limit=10').
-    and_return({ status: 200, body: response})
-        
+    allow_any_instance_of(MusicBrainz::Client).to receive(:get_contents)
+      .with('http://musicbrainz.org/ws/2/artist?query=artist:"Chris+Martin"&limit=10')
+      .and_return({ status: 200, body: response})
+
     matches = MusicBrainz::Artist.search('Chris Martin')
 
-    matches[0][:score].should == 100
-    matches[0][:id].should == "90fff570-a4ef-4cd4-ba21-e00c7261b05a"
-    matches[1][:score].should == 100
-    matches[1][:id].should == "b732a912-af95-472c-be52-b14610734c64"
+    expect(matches[0][:score]).to eq 100
+    expect(matches[0][:id]).to eq "90fff570-a4ef-4cd4-ba21-e00c7261b05a"
+    expect(matches[1][:score]).to eq 100
+    expect(matches[1][:id]).to eq "b732a912-af95-472c-be52-b14610734c64"
   end
 
   it "gets correct result by name" do
     artist = MusicBrainz::Artist.find_by_name('Kasabian')
-    artist.id.should == "69b39eab-6577-46a4-a9f5-817839092033"
+    expect(artist.id).to eq "69b39eab-6577-46a4-a9f5-817839092033"
   end
 
   it "gets correct artist data" do
     artist = MusicBrainz::Artist.find_by_name('Kasabian')
-    artist.id.should == "69b39eab-6577-46a4-a9f5-817839092033"
-    artist.type.should == "Group"
-    artist.name.should == "Kasabian"
-    artist.country.should == "GB"
-    artist.date_begin.year.should == 1999
+    expect(artist.id).to eq "69b39eab-6577-46a4-a9f5-817839092033"
+    expect(artist.type).to eq "Group"
+    expect(artist.name).to eq "Kasabian"
+    expect(artist.country).to eq "GB"
+    expect(artist.date_begin.year).to eq 1997
   end
 
   it "gets correct artist's release groups" do
     release_groups = MusicBrainz::Artist.find_by_name('Kasabian').release_groups
-    release_groups.length.should be >= 16
-    release_groups.first.id.should == "533cbc5f-ec7e-32ab-95f3-8d1f804a5176"
-    release_groups.first.type.should == "Single"
-    release_groups.first.title.should == "Club Foot"
-    release_groups.first.first_release_date.should == Date.new(2004, 5, 10)
-    release_groups.first.urls[:discogs].should == 'http://www.discogs.com/master/125150'
+    expect(release_groups.length).to be >= 16
+    expect(release_groups.first.id).to eq "533cbc5f-ec7e-32ab-95f3-8d1f804a5176"
+    expect(release_groups.first.type).to eq "Single"
+    expect(release_groups.first.title).to eq "Club Foot"
+    expect(release_groups.first.first_release_date).to eq Date.new(2004, 5, 10)
+    expect(release_groups.first.urls[:discogs]).to eq 'http://www.discogs.com/master/125150'
   end
 end

--- a/spec/models/base_model_spec.rb
+++ b/spec/models/base_model_spec.rb
@@ -10,34 +10,34 @@ describe MusicBrainz::BaseModel do
           response = '<release-group><first-release-date></first-release-date></release-group>'
           xml = Nokogiri::XML.parse(response)
           release_group = MusicBrainz::ReleaseGroup.new MusicBrainz::Bindings::ReleaseGroup.parse(xml)
-          release_group.first_release_date.should == Date.new(2030, 12, 31)
+          expect(release_group.first_release_date).to eq Date.new(2030, 12, 31)
         end
       end
-      
+
       context 'year only' do
         it 'returns 1995-12-31' do
           response = '<release-group><first-release-date>1995</first-release-date></release-group>'
           xml = Nokogiri::XML.parse(response)
           release_group = MusicBrainz::ReleaseGroup.new MusicBrainz::Bindings::ReleaseGroup.parse(xml)
-          release_group.first_release_date.should == Date.new(1995, 12, 31)
+          expect(release_group.first_release_date).to eq Date.new(1995, 12, 31)
         end
       end
-      
+
       context 'year and month only' do
         it 'returns 1995-04-30' do
           response = '<release-group><first-release-date>1995-04</first-release-date></release-group>'
           xml = Nokogiri::XML.parse(response)
           release_group = MusicBrainz::ReleaseGroup.new MusicBrainz::Bindings::ReleaseGroup.parse(xml)
-          release_group.first_release_date.should == Date.new(1995, 4, 30)
+          expect(release_group.first_release_date).to eq Date.new(1995, 4, 30)
         end
       end
-      
+
       context 'year, month and day' do
         it 'returns 1995-04-30' do
           response = '<release-group><first-release-date>1995-04-30</first-release-date></release-group>'
           xml = Nokogiri::XML.parse(response)
           release_group = MusicBrainz::ReleaseGroup.new MusicBrainz::Bindings::ReleaseGroup.parse(xml)
-          release_group.first_release_date.should == Date.new(1995, 4, 30)
+          expect(release_group.first_release_date).to eq Date.new(1995, 4, 30)
         end
       end
     end

--- a/spec/models/release_group_spec.rb
+++ b/spec/models/release_group_spec.rb
@@ -5,81 +5,86 @@ require "spec_helper"
 describe MusicBrainz::ReleaseGroup do
   describe '.find' do
     it "gets no exception while loading release group info" do
-      lambda {
+      expect {
         MusicBrainz::ReleaseGroup.find("6f33e0f0-cde2-38f9-9aee-2c60af8d1a61")
-      }.should_not raise_error(Exception)
+      }.to_not raise_error(Exception)
     end
-  
+
     it "gets correct instance" do
       release_group = MusicBrainz::ReleaseGroup.find("6f33e0f0-cde2-38f9-9aee-2c60af8d1a61")
-      release_group.should be_an_instance_of(MusicBrainz::ReleaseGroup)
+      expect(release_group).to be_an_instance_of(MusicBrainz::ReleaseGroup)
     end
-  
+
     it "gets correct release group data" do
       release_group = MusicBrainz::ReleaseGroup.find("6f33e0f0-cde2-38f9-9aee-2c60af8d1a61")
-      release_group.id.should == "6f33e0f0-cde2-38f9-9aee-2c60af8d1a61"
-      release_group.type.should == "Album"
-      release_group.title.should == "Empire"
-      release_group.first_release_date.should == Date.new(2006, 8, 28)
-      release_group.urls[:wikipedia].should == 'http://en.wikipedia.org/wiki/Empire_(Kasabian_album)'
+      expect(release_group.id).to eq "6f33e0f0-cde2-38f9-9aee-2c60af8d1a61"
+      expect(release_group.type).to eq "Album"
+      expect(release_group.title).to eq "Empire"
+      expect(release_group.first_release_date).to eq Date.new(2006, 8, 28)
+      expect(release_group.urls[:wikipedia]).to eq 'http://en.wikipedia.org/wiki/Empire_(Kasabian_album)'
     end
   end
-  
+
   describe '.search' do
     context 'without type filter' do
       it "searches release group by artist name and title" do
         response = File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/search.xml")).read
-        MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group?query=artist:"Kasabian" AND releasegroup:"Empire"&limit=10').
-        and_return({ status: 200, body: response})
-          
+        allow_any_instance_of(MusicBrainz::Client).to receive(:get_contents)
+          .with('http://musicbrainz.org/ws/2/release-group?query=artist:"Kasabian" AND releasegroup:"Empire"&limit=10')
+          .and_return({ status: 200, body: response})
+
         matches = MusicBrainz::ReleaseGroup.search('Kasabian', 'Empire')
-        matches.length.should be > 0
-        matches.first[:title].should == 'Empire'
-        matches.first[:type].should == 'Album'
+        expect(matches.length).to be > 0
+        expect(matches.first[:title]).to eq 'Empire'
+        expect(matches.first[:type]).to eq 'Album'
       end
     end
-    
+
     context 'with type filter' do
       it "searches release group by artist name and title" do
         matches = MusicBrainz::ReleaseGroup.search('Kasabian', 'Empire', 'Album')
-        matches.length.should be > 0
-        matches.first[:title].should == 'Empire'
-        matches.first[:type].should == 'Album'
+        expect(matches.length).to be > 0
+        expect(matches.first[:title]).to eq 'Empire'
+        expect(matches.first[:type]).to eq 'Album'
       end
     end
   end
-  
+
   describe '.find_by_artist_and_title' do
     it "gets first release group by artist name and title" do
       response = File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/search.xml")).read
-      MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group?query=artist:"Kasabian" AND releasegroup:"Empire"&limit=10').
-      and_return({ status: 200, body: response})
-      
+      allow_any_instance_of(MusicBrainz::Client).to receive(:get_contents)
+        .with('http://musicbrainz.org/ws/2/release-group?query=artist:"Kasabian" AND releasegroup:"Empire"&limit=10')
+        .and_return({ status: 200, body: response})
+
       response = File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/entity.xml")).read
-      MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group/6f33e0f0-cde2-38f9-9aee-2c60af8d1a61?inc=url-rels').
-      and_return({ status: 200, body: response})
-      
+      allow_any_instance_of(MusicBrainz::Client).to receive(:get_contents)
+        .with('http://musicbrainz.org/ws/2/release-group/6f33e0f0-cde2-38f9-9aee-2c60af8d1a61?inc=url-rels')
+        .and_return({ status: 200, body: response})
+
       release_group = MusicBrainz::ReleaseGroup.find_by_artist_and_title('Kasabian', 'Empire')
-      release_group.id.should == '6f33e0f0-cde2-38f9-9aee-2c60af8d1a61'
+      expect(release_group.id).to eq '6f33e0f0-cde2-38f9-9aee-2c60af8d1a61'
     end
   end
-  
+
   describe '#releases' do
     it "gets correct release group's releases" do
-      MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release-group/6f33e0f0-cde2-38f9-9aee-2c60af8d1a61?inc=url-rels').
-      and_return({ status: 200, body: File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/entity.xml")).read})
-      
-      MusicBrainz::Client.any_instance.stub(:get_contents).with('http://musicbrainz.org/ws/2/release?release-group=6f33e0f0-cde2-38f9-9aee-2c60af8d1a61&inc=media+release-groups&limit=100').
-      and_return({ status: 200, body: File.open(File.join(File.dirname(__FILE__), "../fixtures/release/list.xml")).read})
-      
+      allow_any_instance_of(MusicBrainz::Client).to receive(:get_contents)
+        .with('http://musicbrainz.org/ws/2/release-group/6f33e0f0-cde2-38f9-9aee-2c60af8d1a61?inc=url-rels')
+        .and_return({ status: 200, body: File.open(File.join(File.dirname(__FILE__), "../fixtures/release_group/entity.xml")).read})
+
+      allow_any_instance_of(MusicBrainz::Client).to receive(:get_contents)
+        .with('http://musicbrainz.org/ws/2/release?release-group=6f33e0f0-cde2-38f9-9aee-2c60af8d1a61&inc=media+release-groups&limit=100')
+        .and_return({ status: 200, body: File.open(File.join(File.dirname(__FILE__), "../fixtures/release/list.xml")).read})
+
       releases = MusicBrainz::ReleaseGroup.find("6f33e0f0-cde2-38f9-9aee-2c60af8d1a61").releases
-      releases.length.should be >= 5
-      releases.first.id.should == "30d5e730-ce0a-464d-93e1-7d76e4bb3e31"
-      releases.first.status.should == "Official"
-      releases.first.title.should == "Empire"
-      releases.first.date.should == Date.new(2006, 8, 28)
-      releases.first.country.should == "GB"
-      releases.first.type.should == "Album"
+      expect(releases.length).to be >= 5
+      expect(releases.first.id).to eq "30d5e730-ce0a-464d-93e1-7d76e4bb3e31"
+      expect(releases.first.status).to eq "Official"
+      expect(releases.first.title).to eq "Empire"
+      expect(releases.first.date).to eq Date.new(2006, 8, 28)
+      expect(releases.first.country).to eq "GB"
+      expect(releases.first.type).to eq "Album"
     end
   end
 end

--- a/spec/models/release_spec.rb
+++ b/spec/models/release_spec.rb
@@ -4,35 +4,35 @@ require "spec_helper"
 
 describe MusicBrainz::Release do
   it "gets no exception while loading release info" do
-    lambda {
+    expect {
       MusicBrainz::Release.find("2225dd4c-ae9a-403b-8ea0-9e05014c778f")
-    }.should_not raise_error(Exception)
+    }.to_not raise_error(Exception)
   end
 
   it "gets correct instance" do
     release = MusicBrainz::Release.find("2225dd4c-ae9a-403b-8ea0-9e05014c778f")
-    release.should be_an_instance_of(MusicBrainz::Release)
+    expect(release).to be_an_instance_of(MusicBrainz::Release)
   end
 
   it "gets correct release data" do
     release = MusicBrainz::Release.find("b94cb547-cf7a-4357-894c-53c3bf33b093")
-    release.id.should == "b94cb547-cf7a-4357-894c-53c3bf33b093"
-    release.title.should == "Humanoid"
-    release.status.should == "Official"
-    release.date.should == Date.new(2009, 10, 6)
-    release.country.should == "US"
-    release.asin.should == 'B002NOYX6I'
-    release.barcode.should == '602527197692'
-    release.quality.should == 'normal'
-    release.type.should == 'Album'
+    expect(release.id).to eq "b94cb547-cf7a-4357-894c-53c3bf33b093"
+    expect(release.title).to eq "Humanoid"
+    expect(release.status).to eq "Official"
+    expect(release.date).to eq Date.new(2009, 10, 6)
+    expect(release.country).to eq "US"
+    expect(release.asin).to eq 'B002NOYX6I'
+    expect(release.barcode).to eq '602527197692'
+    expect(release.quality).to eq 'normal'
+    expect(release.type).to eq 'Album'
   end
 
   it "gets correct release tracks" do
     tracks = MusicBrainz::Release.find("2225dd4c-ae9a-403b-8ea0-9e05014c778f").tracks
-    tracks.length.should == 11
-    tracks.first.position.should == 1
-    tracks.first.recording_id.should == "b3015bab-1540-4d4e-9f30-14872a1525f7"
-    tracks.first.title.should == "Empire"
-    tracks.first.length.should == 233013
+    expect(tracks.length).to eq 11
+    expect(tracks.first.position).to eq 1
+    expect(tracks.first.recording_id).to eq "b3015bab-1540-4d4e-9f30-14872a1525f7"
+    expect(tracks.first.title).to eq "Empire"
+    expect(tracks.first.length).to eq 233013
   end
 end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -4,20 +4,20 @@ require "spec_helper"
 
 describe MusicBrainz::Track do
   it "gets no exception while loading release info" do
-    lambda {
+    expect {
       MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
-    }.should_not raise_error(Exception)
+    }.to_not raise_error(Exception)
   end
 
   it "gets correct instance" do
     track = MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
-    track.should be_an_instance_of(MusicBrainz::Track)
+    expect(track).to be_an_instance_of(MusicBrainz::Track)
   end
 
   it "gets correct track data" do
     track = MusicBrainz::Track.find("b3015bab-1540-4d4e-9f30-14872a1525f7")
-    track.recording_id.should == "b3015bab-1540-4d4e-9f30-14872a1525f7"
-    track.title.should == "Empire"
-    track.length.should == 233013
+    expect(track.recording_id).to eq "b3015bab-1540-4d4e-9f30-14872a1525f7"
+    expect(track.title).to eq "Empire"
+    expect(track.length).to eq 233013
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "rubygems"
 require "bundler/setup"
 require "musicbrainz"
+require "pry"
 
 RSpec.configure do |c|
   c.order = 'random'


### PR DESCRIPTION
* Replace `should` syntax with `expect` syntax.
* Add pry as a development dependency.
* Fix failing specs.