### PR TITLE
Add track ID

### DIFF
--- a/lib/musicbrainz/bindings/track.rb
+++ b/lib/musicbrainz/bindings/track.rb
@@ -3,6 +3,7 @@ module MusicBrainz
     module Track
       def parse(xml)
         {
+          id: (xml.attribute('id').value rescue nil),
           position: (xml.xpath('./position').text rescue nil),
           recording_id: (xml.xpath('./recording').attribute('id').value rescue nil),
           title: (xml.xpath('./recording/title').text rescue nil),

--- a/lib/musicbrainz/models/track.rb
+++ b/lib/musicbrainz/models/track.rb
@@ -1,5 +1,6 @@
 module MusicBrainz
   class Track < BaseModel
+    field :id, String
     field :position, Integer
     field :recording_id, String
     field :title, String

--- a/spec/bindings/track_spec.rb
+++ b/spec/bindings/track_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe MusicBrainz::Bindings::Track do
+  describe '.parse' do
+    subject(:parse) { described_class.parse(xml) }
+
+    let(:xml) { Nokogiri::XML(<<~XML).at_xpath('track') }
+      <track id="0501cf38-48b7-3026-80d2-717d574b3d6a">
+        <position>1</position>
+        <number>1</number>
+        <length>233013</length>
+        <recording id="b3015bab-1540-4d4e-9f30-14872a1525f7">
+          <title>Empire</title>
+          <length>233013</length>
+          <first-release-date>2006-08-25</first-release-date>
+        </recording>
+      </track>
+    XML
+
+    it 'contains track attributes' do
+      expect(parse).to include(
+        id: '0501cf38-48b7-3026-80d2-717d574b3d6a', position: '1', length: '233013',
+        recording_id: 'b3015bab-1540-4d4e-9f30-14872a1525f7', title: 'Empire'
+      )
+    end
+  end
+end


### PR DESCRIPTION
When fetching tracks from a release, each track is given its own MBID.

This pull request adds a new property `id` on the `Track` model, and updates the track binding to parse the `id` attribute from API responses.

```ruby
release = MusicBrainz::Release.find('3c19711b-b9df-495b-a610-634b1fc48763')
release.tracks.first.id

# => "456f7e7e-87f0-48d5-86b9-f0597d1a1072"
```