### PR TITLE
Add recording ISRC

### DIFF
--- a/lib/musicbrainz/bindings/recording.rb
+++ b/lib/musicbrainz/bindings/recording.rb
@@ -9,7 +9,8 @@ module MusicBrainz
           title: (xml.xpath('./title').text.gsub(/[`’]/, "'") rescue nil),
           artist: (xml.xpath('./artist-credit/name-credit/artist/name').text rescue nil),
           releases: (xml.xpath('./release-list/release/title').map{ |xml| xml.text } rescue []),
-          score: (xml.attribute('score').value.to_i rescue nil)
+          score: (xml.attribute('score').value.to_i rescue nil),
+          isrcs: (xml.xpath('./isrc-list/isrc/@id').map(&:text) rescue [])
         }
       end
 

--- a/lib/musicbrainz/models/base_model.rb
+++ b/lib/musicbrainz/models/base_model.rb
@@ -98,8 +98,10 @@ module MusicBrainz
           else
             val.split("-").map(&:to_i)
           end
-          
+
           Date.new(*val)
+        elsif type == Array
+          Array(val)
         else
           val
         end

--- a/lib/musicbrainz/models/recording.rb
+++ b/lib/musicbrainz/models/recording.rb
@@ -6,10 +6,11 @@ module MusicBrainz
     field :artist, String
 		field :releases, String
 		field :score, Integer
+    field :isrcs, Array
 
     class << self
       def find(id)
-				super({ id: id })
+				super({ id: id, inc: [:isrcs] })
       end
 
 			def search(track_name, artist_name)

--- a/spec/bindings/recording_spec.rb
+++ b/spec/bindings/recording_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe MusicBrainz::Bindings::Recording do
+  describe '.parse' do
+    subject(:parse) { described_class.parse(xml) }
+
+    let(:xml) { Nokogiri::XML(<<~XML).at_xpath('recording') }
+      <recording id="b3015bab-1540-4d4e-9f30-14872a1525f7">
+        <title>Empire</title>
+        <length>233013</length>
+        <first-release-date>2006-08-25</first-release-date>
+        <isrc-list count="1">
+          <isrc id="JPB600760301"/>
+        </isrc-list>
+      </recording>
+    XML
+
+    it 'contains recording attributes' do
+      expect(parse).to include(
+        id: 'b3015bab-1540-4d4e-9f30-14872a1525f7',
+        mbid: 'b3015bab-1540-4d4e-9f30-14872a1525f7', title: 'Empire',
+        isrcs: ['JPB600760301']
+      )
+    end
+  end
+end

--- a/spec/fixtures/recording/find_b3015bab-1540-4d4e-9f30-14872a1525f7.xml
+++ b/spec/fixtures/recording/find_b3015bab-1540-4d4e-9f30-14872a1525f7.xml
@@ -4,5 +4,8 @@
 		<title>Empire</title>
 		<length>233013</length>
 		<first-release-date>2006-08-25</first-release-date>
+		<isrc-list count="1">
+			<isrc id="JPB600760301"/>
+		</isrc-list>
 	</recording>
 </metadata>

--- a/spec/models/recording_spec.rb
+++ b/spec/models/recording_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe MusicBrainz::Recording do
   describe '.find' do
     before(:each) {
-      mock url: 'http://musicbrainz.org/ws/2/recording/b3015bab-1540-4d4e-9f30-14872a1525f7?',
+      mock url: 'http://musicbrainz.org/ws/2/recording/b3015bab-1540-4d4e-9f30-14872a1525f7?inc=isrcs',
            fixture: 'recording/find_b3015bab-1540-4d4e-9f30-14872a1525f7.xml'
     }
     let(:recording) {
@@ -20,6 +20,7 @@ describe MusicBrainz::Recording do
 
     it "gets correct track data" do
       expect(recording.title).to eq "Empire"
+      expect(recording.isrcs).to eq ["JPB600760301"]
     end
   end
 


### PR DESCRIPTION
This pull request adds a new property `isrcs` on the Recording model, and updates the recording binding to parse the attribute from API responses.

```ruby
recording = MusicBrainz::Recording.find('b9ad642e-b012-41c7-b72a-42cf4911f9ff')
recording.isrcs

# => ["JPB600760301"]
```